### PR TITLE
Fix link to local host for expense sample

### DIFF
--- a/cmd/samples/expense/README.md
+++ b/cmd/samples/expense/README.md
@@ -24,6 +24,6 @@ If dummy is not found, run make to build it.
 ```
 ./bin/expense -m trigger
 ```
-* When you see the console print out the expense is created, go to [localhost](http://localhost:8080/list) to approve the expense.
+* When you see the console print out the expense is created, go to [localhost:8099](http://localhost:8099/list) to approve the expense.
 * You should see the workflow complete after you approve the expense. You can also reject the expense.
 * If you see the workflow failed, try to change to a different port number in dummy.go and workflow.go. Then rebuild everything.


### PR DESCRIPTION
see https://github.com/samarabbas/cadence-samples/blob/master/cmd/samples/expense/server/dummy.go#L50